### PR TITLE
Typo: Wikipedia Commons → Wikimedia Commons

### DIFF
--- a/index.html
+++ b/index.html
@@ -380,7 +380,7 @@ FRIEDEL WOLFF
 <div id="footer">
   <div class="container">
     <p>Copyright &copy; Numbertext.org. Designed by <a href="http://www.templatewire.com" rel="nofollow">TemplateWire</a>.
-    Cover Photo: <a href="https://commons.wikimedia.org/wiki/File:Tablet_with_Cuneiform_Inscription_LACMA_M.79.106.2_(2_of_4).jpg">Wikipedia Commons</a></p>
+    Cover Photo: <a href="https://commons.wikimedia.org/wiki/File:Tablet_with_Cuneiform_Inscription_LACMA_M.79.106.2_(2_of_4).jpg">Wikimedia Commons</a></p>
   </div>
 </div>
 


### PR DESCRIPTION
Fixed a trivial typo in the footer. See also https://www.mediawiki.org/wiki/Differences_between_Wikipedia,_Wikimedia,_MediaWiki,_and_wiki